### PR TITLE
Str::beforeLast() の誤訳を修正

### DIFF
--- a/translation-ja/helpers.md
+++ b/translation-ja/helpers.md
@@ -1121,7 +1121,7 @@ Laravelはさまざまな、グローバル「ヘルパ」PHP関数を用意し�
 <a name="method-str-before-last"></a>
 #### `Str::beforeLast()` {#collection-method}
 
-`Str::beforeLast`メソッドは、文字列で指定値が現れる最初の場所から、前の部分を返します。
+`Str::beforeLast`メソッドは、文字列で指定値が現れる最後の場所から、前の部分を返します。
 
     use Illuminate\Support\Str;
 


### PR DESCRIPTION
指定値が現れる最初の場所から前の部分を返すのは `Str::before()` の動作で `Str::beforeLast()` は最後の出現場所から前の部分を返します。

```
>>> Str::before('This is my name', 'is');
=> "Th"
>>> Str::before('This is island', 'is');
=> "Th"
>>>
>>> Str::beforeLast('This is my name', 'is');
=> "This "
>>> Str::beforeLast('This is island', 'is');
=> "This is "
```